### PR TITLE
Atomic read during logging

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -155,7 +155,7 @@ func testLru(testParams TestParams, testData TestData) {
 						"Progress",
 						zap.Int("thread", i),
 						zap.Int64("count", cycles),
-						zap.Int64("N", N),
+						zap.Int64("N", atomic.LoadInt64(&N)),
 					)
 				}
 				key, value := testData.RandomKV()


### PR DESCRIPTION
Missed in previous commit since logging happens infrequently. Sorry danger.