### PR TITLE
replacing math/rand with math/rand/v2

### DIFF
--- a/bench/lazylru_benchmark_test.go
+++ b/bench/lazylru_benchmark_test.go
@@ -2,7 +2,7 @@ package main_test
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strconv"
 	"testing"
@@ -48,8 +48,8 @@ func (bc benchconfig) Generic(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ix := rand.Intn(bc.keyCount)      //nolint:gosec
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		ix := rand.IntN(bc.keyCount)
+		if rand.Float64() < bc.readRate {
 			lru.Get(keys[ix])
 		} else {
 			lru.Set(keys[ix], ix)
@@ -67,8 +67,8 @@ func (bc benchconfig) GenInterface(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ix := rand.Intn(bc.keyCount)      //nolint:gosec
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		ix := rand.IntN(bc.keyCount)
+		if rand.Float64() < bc.readRate {
 			lru.Get(keys[ix])
 		} else {
 			lru.Set(keys[ix], ix)

--- a/bench/test_data.go
+++ b/bench/test_data.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"math/rand"
+	"math/rand/v2"
 )
 
 const validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -9,7 +9,7 @@ const validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567
 func randomString(size int) string {
 	retval := make([]byte, size)
 	for i := 0; i < len(retval); i++ {
-		retval[i] = validChars[rand.Intn(len(validChars))] //nolint:gosec
+		retval[i] = validChars[rand.IntN(len(validChars))]
 	}
 	return string(retval)
 }
@@ -40,7 +40,7 @@ func NewTestData(count int) TestDataSimple {
 
 // RandomKV retrieves a random key/value pair
 func (td TestDataSimple) RandomKV() (string, string) {
-	kv := td[rand.Intn(len(td))] //nolint: gosec
+	kv := td[rand.IntN(len(td))]
 	return kv.Key, kv.Value
 }
 

--- a/containers/heap/heap_test.go
+++ b/containers/heap/heap_test.go
@@ -5,7 +5,7 @@
 package heap
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 )
 
@@ -202,7 +202,7 @@ func TestFix(t *testing.T) {
 	h.verify(t, 0)
 
 	for i := 100; i > 0; i-- {
-		elem := rand.Intn(h.Len()) //nolint:gosec
+		elem := rand.IntN(h.Len())
 		if i&1 == 0 {
 			(*h)[elem] *= 2
 		} else {

--- a/generic/containers/heap/heap_test.go
+++ b/generic/containers/heap/heap_test.go
@@ -5,7 +5,7 @@
 package heap
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 )
 
@@ -202,7 +202,7 @@ func TestFix(t *testing.T) {
 	h.verify(t, 0)
 
 	for i := 100; i > 0; i-- {
-		elem := rand.Intn(h.Len()) //nolint:gosec
+		elem := rand.IntN(h.Len())
 		if i&1 == 0 {
 			(*h)[elem] *= 2
 		} else {

--- a/generic/lazylru.go
+++ b/generic/lazylru.go
@@ -2,7 +2,7 @@ package lazylru
 
 import (
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -176,7 +176,7 @@ func (lru *LazyLRU[K, V]) reap(start int, deathList []*item[K, V]) {
 			break
 		}
 		if start < 0 {
-			start = rand.Intn(len(lru.items)) //nolint:gosec
+			start = rand.IntN(len(lru.items))
 		}
 		end := start + 100 // why 100? no idea
 		if end > len(lru.items) {

--- a/generic/lazylru_benchmark_test.go
+++ b/generic/lazylru_benchmark_test.go
@@ -2,7 +2,7 @@ package lazylru_test
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strconv"
 	"testing"
@@ -61,9 +61,8 @@ func (bc benchconfig) InterfaceArray(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if iv, ok := lru.Get(keys[ix]); !ok {
 				continue
@@ -91,9 +90,8 @@ func (bc benchconfig) GenericArray(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if v, ok := lru.Get(keys[ix]); !ok {
 				continue
@@ -115,9 +113,8 @@ func (bc benchconfig) InterfaceStructPtr(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if iv, ok := lru.Get(keys[ix]); !ok {
 				continue
@@ -145,9 +142,8 @@ func (bc benchconfig) GenericStructPtr(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if v, ok := lru.Get(keys[ix]); !ok {
 				continue
@@ -169,9 +165,8 @@ func (bc benchconfig) InterfaceValue(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if iv, ok := lru.Get(keys[ix]); !ok {
 				continue
@@ -199,9 +194,8 @@ func (bc benchconfig) GenericValue(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if v, ok := lru.Get(keys[ix]); !ok {
 				continue

--- a/generic/sharded/lazylru_benchmark_test.go
+++ b/generic/sharded/lazylru_benchmark_test.go
@@ -2,7 +2,7 @@ package sharded_test
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strconv"
 	"sync"
@@ -66,14 +66,12 @@ func (bc benchconfig) Run(b *testing.B) {
 	b.ResetTimer()
 	var wg sync.WaitGroup
 	wg.Add(bc.concurrency)
-	baseTime := time.Now().UnixNano()
 
 	for c := 0; c < bc.concurrency; c++ {
 		go func(c int) {
-			rnd := rand.New(rand.NewSource(baseTime + int64(c))) //nolint:gosec
 			for i := c; i < b.N; i += bc.concurrency {
-				ix := rnd.Intn(bc.keyCount)
-				if rnd.Float64() < bc.readRate {
+				ix := rand.IntN(bc.keyCount)
+				if rand.Float64() < bc.readRate {
 					lru.Get(keys[ix])
 				} else {
 					lru.Set(keys[ix], ix)

--- a/generic/sharded/sharder_test.go
+++ b/generic/sharded/sharder_test.go
@@ -1,7 +1,7 @@
 package sharded_test
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"strconv"
 	"testing"

--- a/lazylru.go
+++ b/lazylru.go
@@ -2,7 +2,7 @@ package lazylru
 
 import (
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -152,7 +152,7 @@ func (lru *LazyLRU[K, V]) reap(start int, deathList []*item[K, V]) {
 			break
 		}
 		if start < 0 {
-			start = rand.Intn(len(lru.items)) //nolint:gosec
+			start = rand.IntN(len(lru.items))
 		}
 		end := start + 100 // why 100? no idea
 		if end > len(lru.items) {

--- a/lazylru_benchmark_test.go
+++ b/lazylru_benchmark_test.go
@@ -2,7 +2,7 @@ package lazylru_test
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strconv"
 	"testing"
@@ -61,9 +61,8 @@ func (bc benchconfig) InterfaceArray(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if iv, ok := lru.Get(keys[ix]); !ok {
 				continue
@@ -91,9 +90,8 @@ func (bc benchconfig) GenericArray(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if v, ok := lru.Get(keys[ix]); !ok {
 				continue
@@ -115,9 +113,8 @@ func (bc benchconfig) InterfaceStructPtr(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if iv, ok := lru.Get(keys[ix]); !ok {
 				continue
@@ -145,9 +142,8 @@ func (bc benchconfig) GenericStructPtr(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if v, ok := lru.Get(keys[ix]); !ok {
 				continue
@@ -169,9 +165,8 @@ func (bc benchconfig) InterfaceValue(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if iv, ok := lru.Get(keys[ix]); !ok {
 				continue
@@ -199,9 +194,8 @@ func (bc benchconfig) GenericValue(b *testing.B) {
 	runtime.GC()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// ix := rand.Intn(bc.keyCount)      //nolint:gosec
 		ix := i % bc.keyCount
-		if rand.Float64() < bc.readRate { //nolint:gosec
+		if rand.Float64() < bc.readRate {
 			// if true {
 			if v, ok := lru.Get(keys[ix]); !ok {
 				continue

--- a/sharded/lazylru_benchmark_test.go
+++ b/sharded/lazylru_benchmark_test.go
@@ -2,7 +2,7 @@ package sharded_test
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strconv"
 	"sync"
@@ -66,14 +66,12 @@ func (bc benchconfig) Run(b *testing.B) {
 	b.ResetTimer()
 	var wg sync.WaitGroup
 	wg.Add(bc.concurrency)
-	baseTime := time.Now().UnixNano()
 
 	for c := 0; c < bc.concurrency; c++ {
 		go func(c int) {
-			rnd := rand.New(rand.NewSource(baseTime + int64(c))) //nolint:gosec
 			for i := c; i < b.N; i += bc.concurrency {
-				ix := rnd.Intn(bc.keyCount)
-				if rnd.Float64() < bc.readRate {
+				ix := rand.IntN(bc.keyCount)
+				if rand.Float64() < bc.readRate {
 					lru.Get(keys[ix])
 				} else {
 					lru.Set(keys[ix], ix)

--- a/sharded/sharder_test.go
+++ b/sharded/sharder_test.go
@@ -1,7 +1,7 @@
 package sharded_test
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"strconv"
 	"testing"


### PR DESCRIPTION
There is no reason to use math/rand anymore. Also removed all of the `//nolint:gosec` comments throughout the code.