### PR TITLE
always taking at least a read lock on shouldBubble

### DIFF
--- a/lazylru_test.go
+++ b/lazylru_test.go
@@ -532,3 +532,24 @@ func TestConcurrent(t *testing.T) {
 
 	_ = group.Wait()
 }
+
+func TestConcurrentShouldBubble(t *testing.T) {
+	lru := lazylru.NewT[int, int](20, time.Hour)
+
+	var group errgroup.Group
+	group.Go(func() error {
+		for n := 0; n < 1000; n++ {
+			lru.Set(n%20, n)
+		}
+		return nil
+	})
+
+	group.Go(func() error {
+		for n := 0; n < 1000; n++ {
+			lru.Get(n % 20)
+		}
+		return nil
+	})
+
+	_ = group.Wait()
+}


### PR DESCRIPTION
Previously, we were making a dirty read in `Get` when calling `shouldBubble` to see if we should bubble the item up. This creates a race condition with the write path. In cases where it was determined we should bubble up, we would take an exclusive lock, then check again. *Technically*, this is a race condition because we did make that dirty read, though we atoned for our sins with that second read.

Do we care? Well, maybe. The second read should make the action safe enough, but it does trip the race detector. There is no way to tell the race detector that this one is OK, so leaving this race condition in the code means that consumers of the library can't use the race detector for their own code. That's not an acceptable trade-off.

To avoid that, we can take a read lock before checking `shouldBubble`. If the answer is "no," we can just exit the function. If yes, we're going to have to take the exclusive lock anyway, so take the lock, check again, and bubble or not as appropriate. The impact of this lock is <0.5% when the cache is under 75% full and approximately 3% when the cache is over 3% full. That 3% represents only a few nanoseconds, so it's not as bad as it looks at first glance.