### PR TITLE
Scan method on the LRU to iterate over the keys and values

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.6
 
-FROM golang:1.22
+FROM golang:1.23
 
 all-bench:
     BUILD +fmt-bench

--- a/Earthfile
+++ b/Earthfile
@@ -261,7 +261,7 @@ goveralls:
 golangci-lint:
     RUN echo Installing golangci-lint...
     # see https://golangci-lint.run/usage/install/#other-ci
-    RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /go/bin v1.57.2
+    RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /go/bin v1.60.3
     SAVE ARTIFACT /go/bin/golangci-lint /go/bin/golangci-lint
 
 junit-report:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TriggerMail/lazylru
 
-go 1.20
+go 1.23
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
-github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.8 h1:+StwCXwm9PdpiEkPyzBXIy+M9KUb4ODm0Zarf1kS5BM=
 github.com/klauspost/cpuid/v2 v2.2.8/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -9,6 +7,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=

--- a/lazylru_test.go
+++ b/lazylru_test.go
@@ -582,7 +582,9 @@ func TestScanWithExpiration(t *testing.T) {
 	lru.SetTTL(1, 1<<4, 1*time.Hour)
 	lru.SetTTL(2, 2<<4, 1*time.Microsecond) // <~ almost expired
 	lru.SetTTL(3, 3<<4, 1*time.Hour)
-	lru.SetTTL(4, 4<<4, 1*time.Hour)
+	lru.SetTTL(4, 4<<4, 1*time.Microsecond) // <~ almost expired
+	lru.SetTTL(5, 5<<4, 1*time.Hour)
+	lru.SetTTL(6, 6<<4, 1*time.Hour)
 	lru.Reap()
 
 	keys, values := []int{}, []int{}
@@ -593,6 +595,6 @@ func TestScanWithExpiration(t *testing.T) {
 
 	sort.Ints(keys)
 	sort.Ints(values)
-	require.Equal(t, []int{0, 1, 3, 4}, keys)
-	require.Equal(t, []int{0, 16, 48, 64}, values)
+	require.Equal(t, []int{0, 1, 3, 5, 6}, keys)
+	require.Equal(t, []int{0, 16, 48, 80, 96}, values)
 }


### PR DESCRIPTION
### Overview
Scanning the key values in an LRU cache allows you to efficiently manage, analyze, and manipulate the cached data. By scanning, you can identify which keys are still relevant, which ones can be evicted, and how to optimize cache performance or resource utilization. 

> [!IMPORTANT]  
> As we are utilizing the latest Golang iterators, the minimum required Go version for this package is now `v1.23`.

### Use Cases
**Cache Preloading (Warm-up)**: In scenarios where anticipated high traffic or load spikes are expected, scanning the cache keys can identify critical data that should be retained or preloaded. This process, known as cache warm-up, ensures that essential data is readily available, reducing latency and improving system performance during peak times.
**Usage Analytics and Cache Tuning**: Regularly scanning the cache keys provides valuable insights into data access patterns and cache utilization. By analyzing which keys are frequently accessed or close to eviction, it is possible to fine-tune cache parameters, such as size or time-to-live (TTL)

### Usage
`Scan()` returns an iterator that yields current non-expired items from the cache. It iterates over a snapshot of keys taken at the beginning of iteration, checking each key's existence and expiration before yielding its associated value.

```go
for key, value := range lru.Scan() {
  fmt.Println("Items ~>", key, value)
}
```

## Benchmarks
Average times to Scan and extract all the keys from the cache based on 5000 iterations:
```
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
```

| Key Count | min | median | average | max |
| -- | -- | -- | -- | -- |
| 1000 | 13.05µs | 51.32µs | 62.30µs | 455.15µs |
| 100000 | 77.50µs | 407.91µs | 595.30µs | 27145.62µs |
| 1000000 | 526.71µs | 2678.91µs | 2902.60µs | 18077.27µs |
| 10000000 | 164.99µs | 10713.59µs | 11131.20µs | 82050.29µs |